### PR TITLE
Bump Play Slick plugin to 0.8.0; misc other version bumps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,11 @@ name := "activator-play-slick"
 
 version := "1.0-SNAPSHOT"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.2" // or "2.10.4"
 
 libraryDependencies ++= Seq(
-  "org.webjars" %% "webjars-play" % "2.2.2",
-  "com.typesafe.play" %% "play-slick" % "0.7.0"
+  "org.webjars" %% "webjars-play" % "2.3.0",
+  "com.typesafe.play" %% "play-slick" % "0.8.0"
 )
 
 fork in Test := false

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,4 +7,4 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 resolvers += "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.2")


### PR DESCRIPTION
I used your nice Activator Template to test Play Slick 0.8.0. Here's a PR that bumps some versions.

I haven't announced the 0.8.0 release because Play Slick [hasn't made it](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.typesafe.play%22%20AND%20%28a%3A%22play-slick_2.10%22%20OR%20a%3A%22play-slick_2.11%22%29) to Maven Central yet. If you want to test in the meantime, the artifacts are in [OSS Sonatype](https://oss.sonatype.org/content/repositories/releases/com/typesafe/play/).
